### PR TITLE
snapcraft devmode updates

### DIFF
--- a/snap/TODO.snap-improvements
+++ b/snap/TODO.snap-improvements
@@ -1,0 +1,52 @@
+# Improvements
+
+For the initial iterations of the snap, there are several things that were done
+that should be improved going forward (in no particular order):
+
+## Phase 1
+* update to 'confinement: strict'
+* update to 'grade: stable'
+* attempt to relocate as much as possible to snap-specific directories (ie,
+  SNAP, SNAP_DATA, SNAP_COMMON, SNAP_USER_DATA and SNAP_USER_COMMON)
+* put large directories in SNAP_COMMON to avoid costly resource consumption on
+  refresh
+* when unable to relocate to snap-specific directories (eg, recompiling or
+  option arguments are not an option), use layouts. Eg, in
+  the snapcraft.yaml:
+    passthrough:
+      layout:
+        /etc/cni:
+          symlink: $SNAP_COMMON/etc/cni
+        /opt/cni:
+          symlink: $SNAP/opt/cni
+        /var/lib/cni:
+          symlink: $SNAP_COMMON/var/lib/cni
+  see https://snapcraft.io/docs/snap-layouts
+* use rest APIs with cert auth due to limitations in go libs that etcd uses
+  surrounding UNIX sockets (not a problem if etcd is remote)
+  - https://github.com/ubuntu/microk8s/pull/607#pullrequestreview-278033874
+* ensure newly added hooks have their own 'plugs' so they don't automatically
+  get docker-privileged, k8s-kubelet, k8s-kubeproxy, etc. Eg, if add the
+  configure hook, use:
+    hooks:
+      configure:
+        plugs:
+        - network
+* determine if personal-files interface is required for kubectl, and if not,
+  remove dot-kube
+* avoid use of sudo within the snap itself
+* always use snapctl instead of systemctl
+* ensure that only verified cert auth is used for all network APIs
+
+## Phase 2 or earlier
+* remove the need for kernel-module-control and instead adjust docker-support
+  (for containerd/ctr) and kubernetes-support (for kube-proxy) to use the kmod
+  backend to have snapd load the modules we need on our behalf
+* determine if docker-privileged is required and if not, drop it
+* determine if kubectl can only use the rest APIs and reduce its plugs to
+  'network' (thus removing all the privileged interfaces)
+* limit access to certs/etc to specific group to avoid local privilege
+  escalation (per Tim, phase 2). See:
+  - https://github.com/ubuntu/microk8s/pull/608
+* determine if home interface is required for kubectl, and if not, remove or
+  request that it not be auto-connected

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,8 +70,14 @@ apps:
   kubectl:
     command: kubectl.wrapper
     plugs:
-      - network
-      - network-bind
+    - firewall-control
+    - hardware-observe
+    - k8s-kubelet
+    - mount-observe
+    - network-bind
+    - network-control
+    - process-control
+    - system-observe
 
 parts:
   setup:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,12 @@ plugs:
     write:
     - $HOME/.kube
 
+# If hooks are used, be sure they don't inherit the top-level plugs
+#hooks. Eg:
+#  configure:
+#    plugs:
+#    - network
+
 apps:
   containerd:
     command: containerd.wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,10 @@ plugs:
   k8s-kubeproxy:
     flavor: kubeproxy
     interface: kubernetes-support
+  dot-kube:
+    interface: personal-files
+    write:
+    - $HOME/.kube
 
 apps:
   containerd:
@@ -70,8 +74,10 @@ apps:
   kubectl:
     command: kubectl.wrapper
     plugs:
+    - dot-kube
     - firewall-control
     - hardware-observe
+    - home
     - k8s-kubelet
     - mount-observe
     - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,33 +9,56 @@ description: |
 grade: devel
 confinement: devmode
 
+plugs:
+  k8s-kubelet:
+    flavor: kubelet
+    interface: kubernetes-support
+  k8s-kubeproxy:
+    flavor: kubeproxy
+    interface: kubernetes-support
+
 apps:
   containerd:
     command: containerd.wrapper
     daemon: simple
     plugs:
-      - network
-      - network-bind
+    - docker-support
+    - firewall-control
+    - network-bind
+    - network-control
 
   kubelet:
     command: kubelet.wrapper
     daemon: simple
     plugs:
-      - network
-      - network-bind
+    - firewall-control
+    - hardware-observe
+    - k8s-kubelet
+    - mount-observe
+    - network-bind
+    - network-control
+    - process-control
+    - system-observe
 
   kube-proxy:
     command: kube-proxy
     daemon: simple
     plugs:
-      - network
-      - network-bind
+    - firewall-control
+    - k8s-kubeproxy
+    - kernel-module-observe
+    - mount-observe
+    - network-bind
+    - network-observe
+    - system-observe
 
   ctr:
     command: ctr.wrapper
     plugs:
-      - network
-      - network-bind
+    - docker-support
+    - firewall-control
+    - network-bind
+    - network-control
 
   kubectl:
     command: kubectl.wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ grade: devel
 confinement: devmode
 
 plugs:
+  docker-privileged:
+    interface: docker-support
+    privileged-containers: true
   k8s-kubelet:
     flavor: kubelet
     interface: kubernetes-support
@@ -22,6 +25,7 @@ apps:
     command: containerd.wrapper
     daemon: simple
     plugs:
+    - docker-privileged
     - docker-support
     - firewall-control
     - network-bind
@@ -55,6 +59,7 @@ apps:
   ctr:
     command: ctr.wrapper
     plugs:
+    - docker-privileged
     - docker-support
     - firewall-control
     - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ apps:
     - docker-privileged
     - docker-support
     - firewall-control
+    - kernel-module-control
     - network-bind
     - network-control
 
@@ -50,6 +51,7 @@ apps:
     plugs:
     - firewall-control
     - k8s-kubeproxy
+    - kernel-module-control
     - kernel-module-observe
     - mount-observe
     - network-bind


### PR DESCRIPTION
* snapcraft.yaml: add known required plugs
* snapcraft.yaml: add docker-privileged
    Add the docker-privileged plug and have containerd/ctr plugs it. This
    allows containerd to manage so-called 'privileged containers' in case
    this snap needs it.
* snapcraft.yaml: add kernel-module-control
    kernel-module-control would ideally not be needed, especially for
    kube-proxy. Instead we should update the kubernetes-support interface's
    kmod backend to have snapd load the modules we require.
* snapcraft.yaml: update plugs for kubectl
    Ideally kubectl would only use rest APIs and therefore need only to
    plugs 'network' and perhaps a couple other not very privileged
    interfaces. With microk8s strict mode investigation this proved not to
    be the case, but perhaps this can be refined in a future iteration.
* snapcraft.yaml: add dot-kube and home interfaces to kubectl
    dot-kube can likely be handled by doing nothing and relying on $HOME
    being set to SNAP_USER_DATA. If so, dot-kube can be dropped.
    
    The home interface is not required and users can put files in the
    SNAP_USER* directories instead. Having home adds some convenience, but
    should possibly request a snap declaration to not auto-connect it (like
    it is on classic distro).
* add snap/TODO.snap-improvements as a high-level TODO list
* snapcraft.yaml: add comment about hooks and top-level plugs