### PR TITLE
add patches/runc-patches/snap-runc-no-pivot-root.patch

### DIFF
--- a/patches/runc-patches/snap-runc-no-pivot-root.patch
+++ b/patches/runc-patches/snap-runc-no-pivot-root.patch
@@ -1,0 +1,26 @@
+diff -Naur runc.orig/libcontainer/rootfs_linux.go runc/libcontainer/rootfs_linux.go
+--- runc.orig/libcontainer/rootfs_linux.go	2020-01-28 18:15:40.741907200 +0000
++++ runc/libcontainer/rootfs_linux.go	2020-01-28 23:09:28.050395249 +0000
+@@ -98,6 +98,9 @@
+ 		return newSystemErrorWithCausef(err, "changing dir to %q", config.Rootfs)
+ 	}
+ 
++	// don't use pivot_root in container setup under snapd since it has
++	// problems with AppArmor
++	/*
+ 	if config.NoPivotRoot {
+ 		err = msMoveRoot(config.Rootfs)
+ 	} else if config.Namespaces.Contains(configs.NEWNS) {
+@@ -105,6 +108,12 @@
+ 	} else {
+ 		err = chroot(config.Rootfs)
+ 	}
++	*/
++	if config.NoPivotRoot {
++		err = msMoveRoot(config.Rootfs)
++	} else {
++		err = chroot(config.Rootfs)
++	}
+ 	if err != nil {
+ 		return newSystemErrorWithCause(err, "jailing process inside rootfs")
+ 	}


### PR DESCRIPTION
Runc by default uses pivot_root when setting up the container unless
NoPivotRoot is specified in the config (or config doesn't use
configs.NEWNS). When runc is being driven by containerd in the snap and
pivot_root is being used, AppArmor denials are seen with the pivoted
root instead of the pre-pivot path, requiring containerd to have
AppArmor policy with more access than is required. Ideally, the snap
would drive the runc containers with NoPivotRoot, but this is apparently
difficult to standardize in different kubernetes environments (eg, EKS).

snap-runc-no-pivot-root.patch updates runc to continue to use
msMoveRoot() when NoPivotRoot is specified, and to use chroot()
otherwise. Since AppArmor mediates accesses in the chroot with the full
path, containerd no longer needs the expanded access.

References:
https://bugs.launchpad.net/apparmor/+bug/1791711/comments/8